### PR TITLE
[ZP-8706] Support Cordova 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenput/cordova-plugin-uwp-oauth",
-  "version": "1.0.1",
+  "version": "22.3.5-H13M27S41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "authentication"
   ],
   "scripts": {
+    "calversion": "TIMESTAMP=$(date '+%y.%-m.%-d-H%HM%MS%S') && echo $TIMESTAMP && npm version $TIMESTAMP",
     "version": "node scripts/update-version-num.js $npm_package_version && git add --all .",
     "postversion": "git push && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "This plugin uses the WebAuthenticationBroker class to connect to OAuth providers.",
   "cordova": {
-    "id": "uwp-oauth",
+    "id": "@zenput/cordova-plugin-uwp-oauth",
     "platforms": [
       "windows"
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenput/cordova-plugin-uwp-oauth",
-  "version": "1.0.1",
+  "version": "22.3.5-H13M27S41",
   "description": "This plugin uses the WebAuthenticationBroker class to connect to OAuth providers.",
   "cordova": {
     "id": "@zenput/cordova-plugin-uwp-oauth",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@zenput/cordova-plugin-uwp-oauth" version="1.0.1">
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@zenput/cordova-plugin-uwp-oauth" version="22.3.5-H13M27S41">
     <name>@zenput/cordova-plugin-uwp-oauth</name>
     <description>
 		This plugin uses the WebAuthenticationBroker class to connect to OAuth providers.

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-uwp-oauth" version="1.0.1">
-    <name>cordova-plugin-uwp-oauth</name>
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@zenput/cordova-plugin-uwp-oauth" version="1.0.1">
+    <name>@zenput/cordova-plugin-uwp-oauth</name>
     <description>
 		This plugin uses the WebAuthenticationBroker class to connect to OAuth providers.
 	</description>


### PR DESCRIPTION
This update brings support for Cordova 11 by using the `@zenput/` scoping everywhere.